### PR TITLE
Add web app to fetch images from Instagram posts

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,20 @@
+# Instagram Photo Fetcher Web App
+
+This simple Flask web app allows you to paste an Instagram post URL and view the images contained in that post. It uses the [Instaloader](https://github.com/instaloader/instaloader) library.
+
+## Local Development
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Then open <http://localhost:8000> in your browser.
+
+## Deployment on Render
+
+Create a new Web Service on [Render](https://render.com) and connect this repository. Render will use `render.yaml` to build and serve the app.
+
+## Disclaimer
+
+This project is not affiliated with or endorsed by Instagram. Use at your own risk and respect Instagram's Terms of Service.

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,30 @@
+from flask import Flask, render_template, request
+import instaloader
+
+app = Flask(__name__)
+loader = instaloader.Instaloader()
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    images = []
+    error = None
+    url = ''
+    if request.method == 'POST':
+        url = request.form.get('url', '')
+        try:
+            shortcode = url.rstrip('/').split('/')[-1]
+            if '?' in shortcode:
+                shortcode = shortcode.split('?')[0]
+            post = instaloader.Post.from_shortcode(loader.context, shortcode)
+            if post.typename == 'GraphSidecar':
+                for node in post.get_sidecar_nodes():
+                    images.append(node.display_url)
+            else:
+                images.append(post.url)
+        except Exception as e:
+            error = str(e)
+    return render_template('index.html', images=images, url=url, error=error)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/webapp/render.yaml
+++ b/webapp/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: instagram-photo-fetcher
+    runtime: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn -w 1 -b 0.0.0.0:8000 app:app

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+instaloader

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Instagram Photo Fetcher</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container py-5">
+  <h1 class="text-center mb-4">Instagram Photo Fetcher</h1>
+  <form method="post" class="mb-4">
+    <div class="input-group">
+      <input type="text" class="form-control" name="url" placeholder="Instagram post URL" value="{{ url }}" required>
+      <button class="btn btn-primary" type="submit">Fetch</button>
+    </div>
+  </form>
+  {% if error %}
+  <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+  <div class="row">
+    {% for img in images %}
+    <div class="col-lg-4 col-md-6 mb-4">
+      <img src="{{ img }}" class="img-fluid rounded">
+    </div>
+    {% endfor %}
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask web app that displays images from an Instagram post URL
- include a template with a simple modern design
- document running locally and deploying on Render
- add requirements and Render service config

## Testing
- `pytest -q`
- `python -m unittest discover -s test -v`
- `pip install -r webapp/requirements.txt`
- `python webapp/app.py` *(fails: Serving Flask app)*

------
https://chatgpt.com/codex/tasks/task_e_683fe5fe0b5c8332a43a5fc66c0f4e56